### PR TITLE
Add Now Playing information to Zopim Chat notes.

### DIFF
--- a/main.js
+++ b/main.js
@@ -267,8 +267,6 @@ $(function () {
 
       ga('send', 'event', 'Player', 'Load', { 'dimension1': gaArtist(), 'dimension2': gaTitle() });
       ga('send', 'event', 'Player', 'Play', { 'dimension1': gaArtist(), 'dimension2': gaTitle() });
-
-
     }
 
     //


### PR DESCRIPTION
Some work is done to prevent us sending information to zopim until it's actually
needed, by the chat being initiated.
